### PR TITLE
feat: add intera-run and basic inter-run restore action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test Action 
+name: Test Action
 
 on:
   pull_request:
@@ -19,15 +19,53 @@ jobs:
         id: test
         uses: ./save
         with:
-          path: .github
-          key: test-stash
+          path: .github/
+          key: test-stash-${{ github.sha }}
+          retention-days: '1'
 
       - name: Check Output
         env:
           ID: ${{ steps.test.outputs.stash-id }}
-          URL: ${{ steps.test.outputs.stash-url }} 
+          URL: ${{ steps.test.outputs.stash-url }}
         run: |
           if [ -z "$ID" -o -z "$URL" ]; then
             echo "Output empty"
             exit 1
           fi
+
+      - name: Check if intra-workflow stash exists
+        id: stash
+        uses: ./restore
+        with:
+          key: test-stash-cross
+          path: test-stash
+
+      - name: Save cross-workflow Stash
+        if: ${{ steps.stash.outputs.stash-hit == 'false' }}
+        uses: ./save
+        with:
+          path: .github/
+          key: test-stash-cross
+          retention-days: '90'
+
+  test-restore:
+    needs: test-save
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test intra-workflow stash
+        uses: ./restore
+        with:
+          key: test-stash-${{ github.sha }}
+          path: intra/.github/
+
+      - run: ls -laR intra
+
+      - name: Test inter-workflow stash
+        uses: ./restore
+        with:
+          key: test-stash-cross
+          path: inter/.github/
+
+      - run: ls -laR inter/

--- a/restore/action.yml
+++ b/restore/action.yml
@@ -1,0 +1,110 @@
+name: "Stash - restore"
+description: "Restore you build cache stash."
+author: assignUser
+
+inputs:
+  key:
+    description: 'Stash key.'
+    required: true
+
+  path:
+    description: 'A file, directory or wildcard pattern that describes what to upload'
+    required: true
+    default: ${{ github.workspace }}
+
+  token:
+    description: 'GITHUB_TOKEN to use to authenticate against the artifacts api.'
+    default: ${{ github.token }}
+    required: true
+outputs:
+  stash-hit:
+    description: >
+      A string ('true' or 'false') that indicates if a stash was restored or not. It is not
+      possible to make this a boolean, as composite-action outputs are always strings. Sorry.
+    value: ${{ steps.output.outputs.stash-hit }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check run for artifact
+      id: check-stash
+      env:
+        GH_TOKEN: "${{ inputs.token }}"
+      shell: bash
+      run: |
+        # Check if an artifact with the same name has been uploaded in the current workflow.
+        # and resolve a glob pattern to an actual name. Most recent hit by "updated_at" is used.
+        gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts > res.json
+
+        stash_name=$(jq '.artifacts
+                          | map(select(.name | test ("${{ inputs.key }}")))
+                          | max_by(.updated_at)
+                          | .name // empty' res.json | tr -d '"')
+
+        if [ -n "$stash_name" ]; then
+          echo "stash_exists=true" >> $GITHUB_OUTPUT
+          echo "stash_name=$stash_name" >> $GITHUB_OUTPUT
+        else
+          echo "stash_exists=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Check across repo
+      id: cross-repo
+      if: ${{ steps.check-stash.outputs.stash_exists == 'false' }}
+      env:
+        GH_TOKEN: "${{ inputs.token }}"
+      shell: bash
+      run: |
+        # Check across other workflow runs.
+        gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          -f name="${{ inputs.key }}" \
+          --method=get \
+          /repos/${{ github.repository }}/actions/artifacts > res.json
+
+        # todo filter for base and current branch
+        jq '.artifacts
+              | map(select(.name | test ("${{ inputs.key }}")))
+              | max_by(.updated_at)' res.json > stash.json
+
+        stash_name=$(jq '.name // empty' stash.json | tr -d '"')
+        if [ -n "$stash_name" ]; then
+          echo "stash_name=$stash_name" >> $GITHUB_OUTPUT
+          echo "stash_run_id=$(jq '.workflow_run.id' stash.json)" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Download Stash from other workflow run
+      shell: bash
+      id: download-cross
+      if: ${{ steps.check-stash.outputs.stash_exists == 'false' && steps.cross-repo.outputs.stash_name != ''}}
+      env:
+        GH_TOKEN: "${{ inputs.token }}"
+        STASH_NAME: "${{ steps.cross-repo.outputs.stash_name }}"
+        STASH_RUN_ID: "${{ steps.cross-repo.outputs.stash_run_id }}"
+      run: |
+        gh run download $STASH_RUN_ID --name $STASH_NAME --dir "${{ inputs.path }}"
+
+    - name: Download Stash from current workflow run
+      id: download-intra
+      if: ${{ steps.check-stash.outputs.stash_exists == 'true' }}
+      continue-on-error: true
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ steps.check-stash.outputs.stash_name || inputs.key }}
+        path: ${{ inputs.path }}
+
+    - name: Set stash-hit Output
+      id: output
+      if: ${{ ! cancelled() }}
+      shell: bash
+      run: |
+        if [ "${{ steps.download-cross.conclusion }}" == "success" -o "${{ steps.download-intra.conclusion }}" == "success" ]; then
+          echo "stash-hit=true" >> $GITHUB_OUTPUT
+        else
+          echo "stash-hit=false" >> $GITHUB_OUTPUT
+          echo "::notice :: No stash found for key: ${{ inputs.key }}"
+        fi

--- a/save/action.yml
+++ b/save/action.yml
@@ -7,7 +7,14 @@ inputs:
     description: 'Stash key.'
     required: true
   path:
-    description: 'A file, directory or wildcard pattern that describes what to upload'
+    description: >
+      A file, directory or wildcard pattern that describes what to upload.
+      For dirs and wildcards some flattening will apply:
+      For wildcards see: https://github.com/actions/upload-artifact?tab=readme-ov-file#upload-using-multiple-paths-and-exclusions
+      For dirs the top level is removed, e.g. with '.github' as the path input, 
+        the artifact will contain the contents of '.github', so adding '.github'
+        as the path in the restore action is necessary. 
+
     required: true
   if-no-files-found:
     description: >


### PR DESCRIPTION
This PR adds a working restore action, it can currently restore caches from the same run or of the (exact) name from across the repo. No branch or PR filtering happens at this point. This is enough to run some basic tests in a separate repo including fork PR runs.

The action currently suffers from some flattening of paths due to the way `actions/upload-artifact` works. The easiest workaround is to use the same `path` input for save and restore. There might be some potential fixes but the simlple ones might interfere when more than one dir is given.

Some quirks I came across during this:
- output is string, need to use explicit string comparison in rest of action
- `tr -d '"'`j important to remove quotes from jq single string output (potentially could use `jq -r` but that might cause other issues?)
- actions/download-artifacts can't download across workflows (without correct token?) `gh` can though.
- setting envvars in composite actions pollutes the parent env and carries state between consecutive calls of the composite action. use outputs instead