### PR TITLE
fix: downgrade actions/upload-artifact version to fix failure in finalizing the artifact

### DIFF
--- a/save/action.yml
+++ b/save/action.yml
@@ -115,7 +115,7 @@ runs:
 
     - name: Upload Stash
       id: upload
-      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
       with:
         name: ${{ steps.mung.outputs.stash_name }}
         path: ${{ inputs.path }}


### PR DESCRIPTION
It seems the bump in the @actions/artifacts  npm dependency in v4.3.1 of `actions/upload-artifact` has introduced a flakey error in the back end communication: https://github.com/actions/upload-artifact/issues/543 

Downgrade to v4.3.0 to avoid this. 