### PR TITLE
fix: update actions/upload-artifact to 4.3.5

### DIFF
--- a/save/action.yml
+++ b/save/action.yml
@@ -115,7 +115,7 @@ runs:
 
     - name: Upload Stash
       id: upload
-      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+      uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
       with:
         name: ${{ steps.mung.outputs.stash_name }}
         path: ${{ inputs.path }}


### PR DESCRIPTION
Fixes 'too many open files' issue:
https://github.com/actions/upload-artifact/issues/485